### PR TITLE
Replace GT911 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ touchscreen:
 The old TFT_eSPI based configuration was removed.  The project now
 uses [LVGL](https://github.com/lvgl/lvgl) together with Espressif's
 `esp_lcd_axs15231b` driver.
+
+The source code previously referenced the GT911 touch controller.  It has been
+updated to use a placeholder `DAXS15231BTouch` class so that the project targets
+the new hardware.

--- a/include/touch_daxs15231b.h
+++ b/include/touch_daxs15231b.h
@@ -1,0 +1,27 @@
+#ifndef TOUCH_DAXS15231B_H
+#define TOUCH_DAXS15231B_H
+
+#include <stdint.h>
+#include <Arduino.h>
+
+struct TP_Point {
+    uint16_t x;
+    uint16_t y;
+};
+
+class DAXS15231BTouch {
+public:
+    bool isTouched = false;
+    TP_Point points[1];
+
+    void begin() {
+        // Initialize hardware (stub)
+    }
+
+    void read() {
+        // Read touch data (stub sets no touch)
+        isTouched = false;
+    }
+};
+
+#endif // TOUCH_DAXS15231B_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,5 +17,6 @@ lib_deps =
     knolleary/PubSubClient@^2.8
     adafruit/Adafruit AHTX0@2.0.5
     https://github.com/lvgl/lvgl.git
+    bodmer/TFT_eSPI@^2.5.43
 build_flags =
     -DAXS15231B_DISPLAY=1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #include <TFT_eSPI.h>
-#include <TAMC_GT911.h>
+#include "touch_daxs15231b.h"
 #include <WiFi.h>
 #include <PubSubClient.h>
 #include <vector>
@@ -9,7 +9,7 @@
 #include "config.h"
 
 TFT_eSPI tft = TFT_eSPI();
-TAMC_GT911 ts = TAMC_GT911(33, 32, 21, 25, 320, 480);
+DAXS15231BTouch ts;
 WiFiClient espClient;
 PubSubClient mqttClient(espClient);
 Adafruit_AHTX0 aht10;


### PR DESCRIPTION
## Summary
- stub out `DAXS15231BTouch` to replace old GT911 driver
- use stub in `main.cpp`
- include TFT_eSPI again for compatibility
- document the GT911 removal in README

## Testing
- `platformio run` *(fails: missing `lv_conf.h`)*

------
https://chatgpt.com/codex/tasks/task_e_6868d98b3b14832bad0ed03a6704063f